### PR TITLE
Upgrade github actions to node v 16.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,14 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - name: Run eslint
         run: npm run lint
   test-node:
@@ -24,13 +24,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - name: Run test with Node.js ${{ matrix.node-version }}
         run: npm run test-node


### PR DESCRIPTION
Addresses: https://github.com/w3c-ccg/vc-api-test-suite-implementations/issues/8

and uses the same version of node as the suites are now running in