### PR TITLE
Add `JsonWebSignature2020 ` tag to DanubeTech `JsonWebSignature2020` issuer.

### DIFF
--- a/implementations/DanubeTech.json
+++ b/implementations/DanubeTech.json
@@ -23,7 +23,7 @@
     "options": {
       "type": "JsonWebSignature2020"
     },
-    "tags": ["VC-API", "JWT"]
+    "tags": ["VC-API", "JsonWebSignature2020"]
   }],
   "verifiers": [{
     "id": "",

--- a/implementations/DanubeTech.json
+++ b/implementations/DanubeTech.json
@@ -23,7 +23,7 @@
     "options": {
       "type": "JsonWebSignature2020"
     },
-    "tags": ["VC-API"]
+    "tags": ["VC-API", "JWT"]
   }],
   "verifiers": [{
     "id": "",


### PR DESCRIPTION
I've run the issuer JsonWebSignature2020 tests and they are mostly passing 13/14 for DanubeTech

https://github.com/w3c-ccg/vc-api-issuer-test-suite/pull/14