### PR TITLE
Fix removal of `Authorization` header.

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -64,11 +64,11 @@ export async function httpPost({
     if(e.response) {
       const {headers: responseHeaders} = e.response;
       // Clone the response headers
-      const newHeaders = new globalThis.Headers(responseHeaders);
+      const newHeaders = new global.Headers(responseHeaders);
       // delete the Authorization header to prevent
       // oauth2 headers potentially in logs
       newHeaders.delete('Authorization');
-      const newResponse = new globalThis.Response(e.response, {
+      const newResponse = new global.Response(e.response, {
         headers: newHeaders
       });
       e.response = newResponse;

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -62,7 +62,16 @@ export async function httpPost({
     // delete the Authorization header to prevent
     // oauth2 headers potentially in logs
     if(e.response) {
-      e.response.headers.delete('Authorization');
+      const {headers: responseHeaders} = e.response;
+      // Clone the response headers
+      const newHeaders = new globalThis.Headers(responseHeaders);
+      // delete the Authorization header to prevent
+      // oauth2 headers potentially in logs
+      newHeaders.delete('Authorization');
+      const newResponse = new globalThis.Response(e.response, {
+        headers: newHeaders
+      });
+      e.response = newResponse;
     }
     error = e;
   }


### PR DESCRIPTION
This fix needs to go in before the module updates since some of the tests on `issuer` and `di-ed25519` test suites are failing on `main` branch due to the immutable headers type error.