### PR TITLE
Adds the VC-API tag to mavennet issuers and verifiers.

### DIFF
--- a/implementations/Mavennet.json
+++ b/implementations/Mavennet.json
@@ -10,11 +10,11 @@
   "issuers": [{
     "id": "did:key:z6MkfFjyzk5CKMdnLacqay3kLMMaZEvKr8yxhks2HezmF4X3",
     "endpoint": "https://api-staging.refiner.neoflow.energy/credentials/issue",
-    "tags": ["OAuth2"]
+    "tags": ["OAuth2", "Mavennet", "VC-API"]
   }],
   "verifiers": [{
     "id": "",
     "endpoint": "https://api-staging.refiner.neoflow.energy/credentials/verify",
-    "tags": ["OAuth2"]
+    "tags": ["OAuth2", "Mavennet", "VC-API"]
   }]
 }


### PR DESCRIPTION
I forgot to mention adding tags for suites, so the tag `VC-API` means that the relevant issuers and verifiers will be run in the `vc-api-issuer-test-suite` and `vc-api-verifier-test-suite` I also added a tag `Mavennet` so we can run tests on your endpoint solo. That helped a lot with debugging some of the issues with the oauth2 code.