### PR TITLE
Filter by tag returns respective endpoint

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,8 +12,8 @@ export const implementations = new Map(keyValues);
 export const allImplementations = implementations;
 
 /**
- * Takes in a Map and a filter and returns
- * an object with match and nonMatch Maps.
+ * Takes in a Map and a predicate and returns
+ * a map with matches and a map with non-matches.
  *
  * @example filterImplementations({filter: (
  *   {value}) => value.issuers.some(i => i.tags.has('foo'))});
@@ -22,10 +22,10 @@ export const allImplementations = implementations;
  * @param {Map} [options.implementations=allImplementations] - A Map of
  *   implementations.
  * @param {Function<boolean>} options.filter - A function to
- * filter the map's entries that returns true or false.
+ * filter the map's entries on that returns true or false.
  *
- * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
- *   and non-matching Maps with respective endpoints.
+ * @returns {Object<string, Map>} Returns an object with matching
+ *   and non-matching maps.
  */
 export const filterImplementations = ({
   implementations = allImplementations,
@@ -33,12 +33,12 @@ export const filterImplementations = ({
 }) => {
   const match = new Map();
   const nonMatch = new Map();
-  for(const [implementationName, implementation] of implementations) {
-    const endpoints = filter({name: implementationName, implementation});
-    if(endpoints.length > 0) {
-      match.set(implementationName, {endpoints, implementation});
+  for(const [key, value] of implementations) {
+    const result = filter({key, value});
+    if(result === true) {
+      match.set(key, value);
     } else {
-      nonMatch.set(implementationName, {endpoints, implementation});
+      nonMatch.set(key, value);
     }
   }
   return {match, nonMatch};
@@ -56,18 +56,81 @@ export const filterImplementations = ({
  * @param {string} [options.property='issuers'] - The property to search for on
  *   an implementation.
  *
- * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
- *   and non-matching Maps with the endpoints matching the property and filter.
+ * @returns {Object<string, Map>} Returns an object with matching
+ *   and non-matching maps.
  */
 export const filterByTag = ({
   implementations = allImplementations,
   tags = [],
   property = 'issuers'
 } = {}) => {
-  const filter = ({implementation}) => {
-    // if the property doesn't exist just use an empty array
-    return (implementation[property] || []).filter(
+  const filter = ({value}) => {
+    // if the property doesn't exist just use some on an empty array
+    return (value[property] || []).some(
       endpoint => tags.some(tag => endpoint.tags.has(tag)));
   };
   return filterImplementations({implementations, filter});
+};
+
+export const endpoints = {
+/**
+ * Takes in a Map and a filter and returns
+ * an object with match and nonMatch Maps.
+ *
+ * @example endpoints.filter({filter: (
+ *   {value}) => value.issuers.some(i => i.tags.has('foo'))});
+ *
+ * @param {object} options - Options to use.
+ * @param {Map} [options.implementations=allImplementations] - A Map of
+ *   implementations.
+ * @param {Function<boolean>} options.filter - A function to
+ * filter the map's entries that returns true or false.
+ *
+ * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
+ *   and non-matching Maps with respective endpoints.
+ */
+  filter({
+    implementations = allImplementations,
+    filter
+  }) {
+    const match = new Map();
+    const nonMatch = new Map();
+    for(const [implementationName, implementation] of implementations) {
+      const endpoints = filter({name: implementationName, implementation});
+      if(endpoints.length > 0) {
+        match.set(implementationName, {endpoints, implementation});
+      } else {
+        nonMatch.set(implementationName, {endpoints, implementation});
+      }
+    }
+    return {match, nonMatch};
+  },
+  /**
+ * Filters endpoints by tags on a property in the settings.
+ *
+ * @example endpoints.filterByTag({property: 'issuers', tags: ['vc-api']})
+ *
+ * @param {object} options - Options to use.
+ * @param {Map} [options.implementations=allImplementations] -
+ *   Implementations to use.
+ * @param {Array<string>} [options.tags=[]] - Tags to search for.
+ * @param {string} [options.property='issuers'] - The property to search for
+ * on an implementation.
+ *
+ * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
+ *   and non-matching Maps with the endpoints matching the property and
+ *   filter.
+ */
+  filterByTag({
+    implementations = allImplementations,
+    tags = [],
+    property = 'issuers'
+  } = {}) {
+    const filter = ({implementation}) => {
+      // if the property doesn't exist just use an empty array
+      return (implementation[property] || []).filter(
+        endpoint => tags.some(tag => endpoint.tags.has(tag)));
+    };
+    return endpoints.filter({implementations, filter});
+  }
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,7 +25,7 @@ export const allImplementations = implementations;
  * filter the map's entries that returns true or false.
  *
  * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
- *   and non-matching Maps.
+ *   and non-matching Maps with respective endpoints.
  */
 export const filterImplementations = ({
   implementations = allImplementations,
@@ -34,11 +34,11 @@ export const filterImplementations = ({
   const match = new Map();
   const nonMatch = new Map();
   for(const [implementationName, implementation] of implementations) {
-    const result = filter({key: implementationName, value: implementation});
-    if(result === true) {
-      match.set(implementationName, implementation);
+    const endpoints = filter({name: implementationName, implementation});
+    if(endpoints.length > 0) {
+      match.set(implementationName, {endpoints, implementation});
     } else {
-      nonMatch.set(implementationName, implementation);
+      nonMatch.set(implementationName, {endpoints, implementation});
     }
   }
   return {match, nonMatch};
@@ -57,17 +57,17 @@ export const filterImplementations = ({
  *   an implementation.
  *
  * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
- *   and non-matching Maps.
+ *   and non-matching Maps with the endpoints matching the property and filter.
  */
 export const filterByTag = ({
   implementations = allImplementations,
   tags = [],
   property = 'issuers'
 } = {}) => {
-  const filter = ({value}) => {
+  const filter = ({implementation}) => {
     // if the property doesn't exist just use an empty array
-    return (value[property] || []).some(
+    return (implementation[property] || []).filter(
       endpoint => tags.some(tag => endpoint.tags.has(tag)));
   };
-  return filterImplementations({implementations, filter});
+  return filterImplementations(implementations, filter);
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,8 +12,8 @@ export const implementations = new Map(keyValues);
 export const allImplementations = implementations;
 
 /**
- * Takes in a Map and a predicate and returns
- * a map with matches and a map with non-matches.
+ * Takes in a Map and a filter and returns
+ * an object with match and nonMatch Maps.
  *
  * @example filterImplementations({filter: (
  *   {value}) => value.issuers.some(i => i.tags.has('foo'))});
@@ -22,10 +22,10 @@ export const allImplementations = implementations;
  * @param {Map} [options.implementations=allImplementations] - A Map of
  *   implementations.
  * @param {Function<boolean>} options.filter - A function to
- * filter the map's entries on that returns true or false.
+ * filter the map's entries that returns true or false.
  *
- * @returns {Object<string, Map>} Returns an object with matching
- *   and non-matching maps.
+ * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
+ *   and non-matching Maps.
  */
 export const filterImplementations = ({
   implementations = allImplementations,
@@ -33,12 +33,12 @@ export const filterImplementations = ({
 }) => {
   const match = new Map();
   const nonMatch = new Map();
-  for(const [key, value] of implementations) {
-    const result = filter({key, value});
+  for(const [implementationName, implementation] of implementations) {
+    const result = filter({key: implementationName, value: implementation});
     if(result === true) {
-      match.set(key, value);
+      match.set(implementationName, implementation);
     } else {
-      nonMatch.set(key, value);
+      nonMatch.set(implementationName, implementation);
     }
   }
   return {match, nonMatch};
@@ -56,8 +56,8 @@ export const filterImplementations = ({
  * @param {string} [options.property='issuers'] - The property to search for on
  *   an implementation.
  *
- * @returns {Object<string, Map>} Returns an object with matching
- *   and non-matching maps.
+ * @returns {{match: Map, nonMatch: Map}} Returns an object with matching
+ *   and non-matching Maps.
  */
 export const filterByTag = ({
   implementations = allImplementations,
@@ -65,7 +65,7 @@ export const filterByTag = ({
   property = 'issuers'
 } = {}) => {
   const filter = ({value}) => {
-    // if the property doesn't exist just use some on an empty array
+    // if the property doesn't exist just use an empty array
     return (value[property] || []).some(
       endpoint => tags.some(tag => endpoint.tags.has(tag)));
   };

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,5 +69,5 @@ export const filterByTag = ({
     return (implementation[property] || []).filter(
       endpoint => tags.some(tag => endpoint.tags.has(tag)));
   };
-  return filterImplementations(implementations, filter);
+  return filterImplementations({implementations, filter});
 };


### PR DESCRIPTION
`endpoints.filter` returns an Array of matching endpoints. `match` and `nonMatch` are still there, but instead of containing just the implementation they now contain a list of matching endpoints and an implementation. This cuts down on the amount of work in the test suite, but filtering both endpoints and implementations at the same time.