### PR TITLE
Add accessToken cache to prevent multiple calls to access token endpoints

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,9 +5,9 @@ import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
 // the default access token times out in one hour in seconds
-const ttl = 60 * 60 * 1000; // one hour (in milliseconds)
-// caches 50 access tokens max with a ttl of one hour
-const accessTokenCache = new LruCache({max: 50, ttl});
+const ttl = 60 * 60;
+// caches 50 access tokens max
+const accessTokenCache = new LruCache({max: 50});
 
 export async function constructOAuthHeader({
   clientId,

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -74,7 +74,7 @@ async function _getNewAccessToken({
   for(; maxRetries >= 0; --maxRetries) {
     const {
       access_token,
-      expires_in = _expiresIn
+      expires_in = _defaultExpirationTimeInSeconds
     } = await _requestAccessToken({url: token_endpoint, body});
     if(access_token) {
       // convert seconds expires_in to milliseconds ttl for cache

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -1,11 +1,13 @@
 /*!
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
+import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
-// caches access tokens we're assuming the tokens
-// persist at least for the duration of the test run
-const accessTokenCache = new Map();
+// the default access token times out in one hour in seconds
+const ttl = 60 * 60;
+// caches 10 access tokens max with a ttl in ms of one hour
+const accessTokenCache = new LruCache({max: 10, ttl: ttl * 1000});
 
 export async function constructOAuthHeader({
   clientId,
@@ -69,10 +71,14 @@ async function _getNewAccessToken({
     body.append('scopes', scopes.join(' '));
   }
   for(; maxRetries >= 0; --maxRetries) {
-    const access_token = await _requestAccessToken(
-      {url: token_endpoint, body});
+    const {
+      access_token,
+      expires_in = ttl
+    } = await _requestAccessToken({url: token_endpoint, body});
     if(access_token) {
-      accessTokenCache.set(client_id, access_token);
+      // convert seconds expires_in to milliseconds ttl for cache
+      const options = {ttl: expires_in * 1000};
+      accessTokenCache.set(client_id, access_token, options);
       return {accessToken: access_token};
     }
   }
@@ -98,7 +104,7 @@ async function _requestAccessToken({url, body}) {
     throw error;
   }
   if(data && data.access_token) {
-    return data.access_token;
+    return data;
   }
-  return false;
+  return {};
 }

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -3,6 +3,10 @@
  */
 import {makeHttpsRequest} from './requests.js';
 
+// caches access tokens we're assuming the tokens
+// persist at least for the duration of the test run
+const accessTokenCache = new Map();
+
 export async function constructOAuthHeader({
   clientId,
   clientSecret,
@@ -50,6 +54,10 @@ async function _getNewAccessToken({
   scopes,
   maxRetries = 3
 }) {
+  const cachedAccessToken = accessTokenCache.get(client_id);
+  if(cachedAccessToken) {
+    return {accessToken: cachedAccessToken};
+  }
   const body = new URLSearchParams({
     client_id,
     client_secret,
@@ -64,6 +72,7 @@ async function _getNewAccessToken({
     const access_token = await _requestAccessToken(
       {url: token_endpoint, body});
     if(access_token) {
+      accessTokenCache.set(client_id, access_token);
       return {accessToken: access_token};
     }
   }

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -4,7 +4,7 @@
 import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
-// the default access token times out in one hour in seconds
+// the default expires_in time for access tokens in seconds
 const _defaultExpirationTimeInSeconds = 60 * 60;
 // caches 50 access tokens max
 const accessTokenCache = new LruCache({max: 50});

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,7 +5,7 @@ import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
 // the default access token times out in one hour in seconds
-const _expiresIn = 60 * 60;
+const _defaultExpirationTimeInSeconds = 60 * 60;
 // caches 50 access tokens max
 const accessTokenCache = new LruCache({max: 50});
 

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,9 +5,9 @@ import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
 // the default access token times out in one hour in seconds
-const ttl = 60 * 60;
-// caches 10 access tokens max with a ttl in ms of one hour
-const accessTokenCache = new LruCache({max: 10, ttl: ttl * 1000});
+const ttl = 60 * 60 * 1000; // one hour (in milliseconds)
+// caches 50 access tokens max with a ttl of one hour
+const accessTokenCache = new LruCache({max: 50, ttl});
 
 export async function constructOAuthHeader({
   clientId,

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -78,7 +78,7 @@ async function _getNewAccessToken({
     if(access_token) {
       // convert seconds expires_in to milliseconds ttl for cache
       const options = {ttl: expires_in * 1000};
-      accessTokenCache.set(client_id, access_token, options);
+      accessTokenCache.set(client_id + scopes, access_token, options);
       return {accessToken: access_token};
     }
   }

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -56,7 +56,7 @@ async function _getNewAccessToken({
   scopes,
   maxRetries = 3
 }) {
-  const cachedAccessToken = accessTokenCache.get(client_id);
+  const cachedAccessToken = accessTokenCache.get(client_id + scopes);
   if(cachedAccessToken) {
     return {accessToken: cachedAccessToken};
   }

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,7 +5,7 @@ import LruCache from 'lru-cache';
 import {makeHttpsRequest} from './requests.js';
 
 // the default access token times out in one hour in seconds
-const ttl = 60 * 60;
+const _expiresIn = 60 * 60;
 // caches 50 access tokens max
 const accessTokenCache = new LruCache({max: 50});
 
@@ -74,7 +74,7 @@ async function _getNewAccessToken({
   for(; maxRetries >= 0; --maxRetries) {
     const {
       access_token,
-      expires_in = ttl
+      expires_in = _expiresIn
     } = await _requestAccessToken({url: token_endpoint, body});
     if(access_token) {
       // convert seconds expires_in to milliseconds ttl for cache

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -56,7 +56,8 @@ async function _getNewAccessToken({
   scopes,
   maxRetries = 3
 }) {
-  const cachedAccessToken = accessTokenCache.get(client_id + scopes);
+  const cacheKey = _getCacheKey({clientId: client_id, scopes});
+  const cachedAccessToken = accessTokenCache.get(cacheKey);
   if(cachedAccessToken) {
     return {accessToken: cachedAccessToken};
   }
@@ -78,7 +79,8 @@ async function _getNewAccessToken({
     if(access_token) {
       // convert seconds expires_in to milliseconds ttl for cache
       const options = {ttl: expires_in * 1000};
-      accessTokenCache.set(client_id + scopes, access_token, options);
+      const cacheKey = _getCacheKey({clientId: client_id, scopes});
+      accessTokenCache.set(cacheKey, access_token, options);
       return {accessToken: access_token};
     }
   }
@@ -107,4 +109,13 @@ async function _requestAccessToken({url, body}) {
     return data;
   }
   return {};
+}
+
+function _getCacheKey({clientId, scopes}) {
+  if(Array.isArray(scopes) && (scopes.length > 0)) {
+    // sort could mutate the order of the scopes set in the manifest
+    // which could cause issues with the request
+    return `${clientId}-${[...scopes].sort()}`;
+  }
+  return clientId;
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@digitalbazaar/http-client": "^3.2.0",
     "app-root-path": "^3.0.0",
     "bnid": "^3.0.0",
+    "lru-cache": "^7.14.0",
     "require-dir": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Each implementation that requires oauth authentication was only hit once for an access token request.
The cache has a ttl set by the `expires_in` value from the oauth access token request.

- [x] Tested with the issuer & verifier test suites and did not result in any regressions.
- [x] Tests made a single access token request.

