### PR TITLE
Export HTTPError from ky.

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -28,45 +28,42 @@ export class Endpoint {
   get tags() {
     return new Set(this.settings.tags);
   }
-  post({json, headers = {}, searchParams, url}) {
+  post({headers = {}, url, ...args}) {
     const {headers: _headers = {}, endpoint, oauth2, zcap} = this.settings;
     if(zcap) {
       return zcapRequest({
         endpoint: url || endpoint,
         zcap,
-        json,
-        headers
+        headers: {..._headers, ...headers},
+        ...args
       });
     }
     return makeHttpsRequest({
       url: url || endpoint,
       method: 'POST',
-      json,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
-  put({json, headers = {}, searchParams, url}) {
+  put({headers = {}, url, ...args}) {
     const {headers: _headers = {}, endpoint, oauth2} = this.settings;
     return makeHttpsRequest({
       url: url || endpoint,
       method: 'PUT',
-      json,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
-  get({headers, searchParams, url} = {}) {
+  get({headers, url, ...args} = {}) {
     const {headers: _headers = {}, endpoint, oauth2} = this.settings;
     return makeHttpsRequest({
       method: 'GET',
       url: url || endpoint,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
 }
-

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,8 @@
 import {Implementation} from './Implementation.js';
 import {implementerFiles} from '../implementations/index.js';
 export {Endpoint} from './Endpoint.js';
+// used to ensure that tests are failing from HTTP Errors
+export {HTTPError} from 'ky';
 
 const keyValues = implementerFiles.map(
   implementation => [implementation.name, new Implementation(implementation)]);


### PR DESCRIPTION
Exports ky's `HTTPError` class so it can be asserted on in tests.

By using this with `error.should.be.instanceOf(HTTPError)` we catch errors in this library that could produce false negative tests.