### PR TITLE
Use ...args to avoid destructuring unused args in Endpoint methods.

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -28,45 +28,42 @@ export class Endpoint {
   get tags() {
     return new Set(this.settings.tags);
   }
-  post({json, headers = {}, searchParams, url}) {
+  post({headers = {}, url, ...args}) {
     const {headers: _headers = {}, endpoint, oauth2, zcap} = this.settings;
     if(zcap) {
       return zcapRequest({
         endpoint: url || endpoint,
         zcap,
-        json,
-        headers
+        headers: {..._headers, ...headers},
+        ...args
       });
     }
     return makeHttpsRequest({
       url: url || endpoint,
       method: 'POST',
-      json,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
-  put({json, headers = {}, searchParams, url}) {
+  put({headers = {}, url, ...args}) {
     const {headers: _headers = {}, endpoint, oauth2} = this.settings;
     return makeHttpsRequest({
       url: url || endpoint,
       method: 'PUT',
-      json,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
-  get({headers, searchParams, url} = {}) {
+  get({headers, url, ...args} = {}) {
     const {headers: _headers = {}, endpoint, oauth2} = this.settings;
     return makeHttpsRequest({
       method: 'GET',
       url: url || endpoint,
       oauth2,
-      searchParams,
-      headers: {..._headers, ...headers}
+      headers: {..._headers, ...headers},
+      ...args
     });
   }
 }
-


### PR DESCRIPTION
This has been tested with:

- vc-api-exchangers-test-suite