### PR TITLE
Add data to _sanitizeResponseHeaders.

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -52,7 +52,7 @@ export async function makeHttpsRequest({
   const {data, statusCode} = _getDataAndStatus({result, error});
   // if a result is returned sanitize it
   if(result) {
-    result = _sanitizeResponseHeaders({response: result});
+    result = _sanitizeResponseHeaders({response: result, data});
   }
   return {result, error, data, statusCode};
 }
@@ -93,7 +93,7 @@ export async function zcapRequest({
   const {data, statusCode} = _getDataAndStatus({result, error});
   // if a result is returned sanitize it
   if(result) {
-    result = _sanitizeResponseHeaders({response: result});
+    result = _sanitizeResponseHeaders({response: result, data});
   }
   return {result, error, data, statusCode};
 }
@@ -122,7 +122,10 @@ function _getDataAndStatus({result = {}, error = {}}) {
 
 function _sanitizeErrorHeaders({error}) {
   if(error.response) {
-    error.response = _sanitizeResponseHeaders({response: error.response});
+    error.response = _sanitizeResponseHeaders({
+      response: error.response,
+      data: error.data
+    });
   }
   if(error.request) {
     error.request = new global.Request(error.request, {
@@ -132,16 +135,16 @@ function _sanitizeErrorHeaders({error}) {
   return error;
 }
 
-function _sanitizeResponseHeaders({response}) {
-  const newResponse = new global.Response(JSON.stringify(response.data), {
+function _sanitizeResponseHeaders({response, data}) {
+  const newResponse = new global.Response(JSON.stringify(data), {
     headers: _sanitizeHeaders({httpMessage: response}),
     status: response.status,
     statusText: response.statusText
   });
-  if(response.data) {
+  if(data) {
     // transfer the already parsed data to the newResponse
     // we are overwriting the data getter in Response here
-    Object.defineProperty(newResponse, 'data', {value: response.data});
+    Object.defineProperty(newResponse, 'data', {value: data});
   }
   return newResponse;
 }


### PR DESCRIPTION
Accounts for some edge cases and removes a node deprecation warning.

This has been tested with

- vc-api-issuer-test-suite
- vc-api-verifier-test-suite
- did-key-test-suite