### PR TITLE
Add LearnCard VC API

### DIFF
--- a/implementations/LearnCard.json
+++ b/implementations/LearnCard.json
@@ -1,0 +1,15 @@
+{
+  "name": "LearnCard",
+  "implementation": "LearnCard",
+  "issuers": [{
+    "id": "did:key:z6MkjSz4mYqcn7dePGuktJ5PxecMkXQQHWRg8Lm6okATyFVh",
+    "endpoint": "https://bridge.learncard.com/credentials/issue",
+    "tags": ["vc-api", "Ed25519Signature2020"]
+
+  }],
+  "verifiers": [{
+    "id": "",
+    "endpoint": "https://bridge.learncard.com/credentials/verify",
+    "tags": ["vc-api", "Ed25519Signature2020"]
+  }]
+}


### PR DESCRIPTION
This adds the [LearnCard](https://www.learncard.com/) VC API to the list of implementations.

I have ran the issuer and verifier test suites and can confirm they are all passing!
