### PR TITLE
fix: use correct name for scope in token request

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -69,7 +69,7 @@ async function _getNewAccessToken({
   });
   // scopes are space separated
   if(scopes && scopes.length > 0) {
-    body.append('scopes', scopes.join(' '));
+    body.append('scope', scopes.join(' '));
   }
   for(; maxRetries >= 0; --maxRetries) {
     const {


### PR DESCRIPTION
The [RFC-6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.4.2) specifies that requested scopes should be provided to a token endpoint in the `scope` parameter (not `scopes` plural).

Fix #56