### PR TITLE
Add Trinsic implementation

### DIFF
--- a/implementations/Trinsic.json
+++ b/implementations/Trinsic.json
@@ -1,0 +1,21 @@
+{
+  "name": "Trinsic",
+  "implementation": "Trinsic",
+  "issuers": [
+    {
+      "id": "https://trinsic.id",
+      "endpoint": "https://interop.connect.trinsic.cloud/vc-api/credentials/issue",
+      "options": {
+        "type": "DataIntegrityProof"
+      },
+      "tags": ["eddsa-2022"]
+    }
+  ],
+  "verifiers": [
+    {
+      "id": "https://trinsic.id",
+      "endpoint": "https://interop.connect.trinsic.cloud/vc-api/credentials/verify",
+      "tags": ["eddsa-2022"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds implementation reference for Trinsic

<details>
  <summary>Test Suite Results</summary>
  
  ```
  eddsa-2022 (create)
    Data Integrity (issuer)
      Trinsic
        ✓ "proof" field MUST exist at top-level of data object.
        ✓ if "proof.id" field exists, it MUST be a valid URL.
        ✓ "proof.type" field MUST exist and be a string.
        ✓ "proof.type" field MUST be "DataIntegrityProof".
        ✓ "proof.cryptosuite" field MUST exist and be a string.
        ✓ "proof.created" field MUST exist and be a valid XMLSCHEMA-11 datetime value.
        ✓ "proof.verificationMethod" field MUST exist and be a valid URL.
        ✓ "proof.proofPurpose" field MUST exist and be a string.
        ✓ "proof.proofValue" field MUST exist and be a string.
        ✓ The "proof.proofValue" field MUST be a multibase-encoded base58-btc encoded value.
        ✓ if "proof.domain" field exists, it MUST be a string.
        ✓ if "proof.challenge" field exists, it MUST be a string.
        ✓ if "proof.previousProof" field exists, it MUST be a string.
    eddsa-2022 (issuer)
      Trinsic
        ✓ The field "cryptosuite" MUST be `eddsa-2022`
        ✓ "proofValue" field when decoded to raw bytes, MUST be 64 bytes in length if the associated public key is 32 bytes or 114 bytes in length if the public key is 57 bytes.
        ✓ "proof" MUST verify when using a conformant verifier.
  eddsa-2022 (verify)
    Data Integrity (verifier)
      Trinsic
        ✓ If the "proof" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof" field is invalid, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.type" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.type" field is not the string "DataIntegrityProof", an "INVALID_PROOF_CONFIGURATION" error MUST be raised.
        ✓ If the "proof.verificationMethod" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.verificationMethod" field is invalid, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.proofPurpose" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.proofPurpose" field is invalid, a  "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.proofPurpose" value does not match "options.expectedProofPurpose", a "MISMATCHED_PROOF_PURPOSE_ERROR" MUST be raised.
        ✓ If the "proof.proofValue" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.proofValue" field is invalid, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.created" field is missing, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.created" field is invalid, a "MALFORMED_PROOF_ERROR" MUST be raised.
        ✓ If the "proof.proofValue" field is not a multibase-encoded base58-btc value, an "INVALID_PROOF_VALUE" error MUST be raised.
        ✓ If the "options.domain" is set and it does not match "proof.domain", an "INVALID_DOMAIN_ERROR" MUST be raised.
        ✓ If the "options.challenge" is set and it does not match "proof.challenge", an "INVALID_CHALLENGE_ERROR" MUST be raised.
    eddsa-2022 cryptosuite (verifier)
      Trinsic
        ✓ MUST verify a valid VC with an eddsa-2022 proof
        ✓ If the "proofValue" field, when decoded to raw bytes, is not 64 bytes in length if the associated public key is 32 bytes in length, or 114 bytes in length if the public key is 57 bytes in length, an INVALID_PROOF_LENGTH error MUST be returned.
        ✓ If a canonicalization algorithm other than URDNA2015 is used, a INVALID_PROOF_VALUE error MUST be returned.
        ✓ If a canonicalization data hashing other than algorithm SHA-2-256 is used, a INVALID_PROOF_VALUE error MUST be returned.
        ✓ If the "cryptosuite" field is not the string "eddsa-2022", an INVALID_PROOF_CONFIGURATION error MUST be returned.
  eddsa-2022 (interop)
    ✓ Trinsic should verify Trinsic


Tests passed 38/38 100%
Tests failed 0/38 0%
Failures 0
Tests skipped 0
Total tests 38
  ```
</details>