### PR TITLE
updates options for mavennet to interop with traceability profile

### DIFF
--- a/implementations/Mavennet.json
+++ b/implementations/Mavennet.json
@@ -7,14 +7,21 @@
     "tokenAudience": "https://api.staging.refiner.neoflow.energy/v1",
     "tokenEndpoint": "https://api.staging.refiner.neoflow.energy/v1/auth"
   },
-  "issuers": [{
-    "id": "did:key:z6MkfFjyzk5CKMdnLacqay3kLMMaZEvKr8yxhks2HezmF4X3",
-    "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/issue",
-    "tags": ["OAuth2", "Mavennet", "vc-api"]
-  }],
-  "verifiers": [{
-    "id": "",
-    "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/verify",
-    "tags": ["OAuth2", "Mavennet", "vc-api"]
-  }]
+  "issuers": [
+    {
+      "id": "did:key:z6MkfFjyzk5CKMdnLacqay3kLMMaZEvKr8yxhks2HezmF4X3",
+      "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/issue",
+      "options": {
+        "type": "Ed25519Signature2018"
+      },
+      "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
+    }
+  ],
+  "verifiers": [
+    {
+      "id": "",
+      "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/verify",
+      "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
+    }
+  ]
 }

--- a/implementations/Mavennet.json
+++ b/implementations/Mavennet.json
@@ -7,21 +7,17 @@
     "tokenAudience": "https://api.staging.refiner.neoflow.energy/v1",
     "tokenEndpoint": "https://api.staging.refiner.neoflow.energy/v1/auth"
   },
-  "issuers": [
-    {
-      "id": "did:key:z6MkfFjyzk5CKMdnLacqay3kLMMaZEvKr8yxhks2HezmF4X3",
-      "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/issue",
-      "options": {
-        "type": "Ed25519Signature2018"
-      },
-      "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
-    }
-  ],
-  "verifiers": [
-    {
-      "id": "",
-      "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/verify",
-      "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
-    }
-  ]
+  "issuers": [{
+    "id": "did:key:z6MkfFjyzk5CKMdnLacqay3kLMMaZEvKr8yxhks2HezmF4X3",
+    "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/issue",
+    "options": {
+      "type": "Ed25519Signature2018"
+    },
+    "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
+  }],
+  "verifiers": [{
+    "id": "",
+    "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/verify",
+    "tags": ["OAuth2", "vc-api", "Ed25519Signature2018"]
+  }]
 }


### PR DESCRIPTION
Current Mavennet issuer is failing because the options field is missing, it is no longer a thing in VC-API but is required in trace interop, adding it in.

Tested against local and it fixed the issue.