### PR TITLE
Update LearnCard VC-API endpoint and DID

### DIFF
--- a/implementations/LearnCard.json
+++ b/implementations/LearnCard.json
@@ -1,15 +1,18 @@
 {
-  "name": "LearnCard",
-  "implementation": "LearnCard",
-  "issuers": [{
-    "id": "did:key:z6MkjSz4mYqcn7dePGuktJ5PxecMkXQQHWRg8Lm6okATyFVh",
-    "endpoint": "https://bridge.learncard.com/credentials/issue",
-    "tags": ["vc-api"]
-
-  }],
-  "verifiers": [{
-    "id": "",
-    "endpoint": "https://bridge.learncard.com/credentials/verify",
-    "tags": ["vc-api"]
-  }]
+    "name": "LearnCard",
+    "implementation": "LearnCard",
+    "issuers": [
+        {
+            "id": "did:key:z6Mkk16aKmGEVkeFu83FsP5bwELFWNf6hqRQhJxxSjrndyFv",
+            "endpoint": "https://vc-api.network.learncard.com/credentials/issue",
+            "tags": ["vc-api"]
+        }
+    ],
+    "verifiers": [
+        {
+            "id": "did:key:z6Mkk16aKmGEVkeFu83FsP5bwELFWNf6hqRQhJxxSjrndyFv",
+            "endpoint": "https://vc-api.network.learncard.com/credentials/verify",
+            "tags": ["vc-api"]
+        }
+    ]
 }


### PR DESCRIPTION
We've replaced our old VC-API endpoint (`bridge.learncard.com`) with a new dedicated service at `vc-api.network.learncard.com`, so this points the LearnCard entry at it.

Changes:
- New endpoint for issuer and verifier
- New issuer DID (`did:key:z6Mkk16a...` — matches the endpoint's `GET /did`)
- Filled in the verifier `id`, which was empty before

We've run the VC-API issuer and verifier suites against the live endpoint and both pass fully (13/13 and 18/18).
